### PR TITLE
More precise errors

### DIFF
--- a/traces/benchmark.go
+++ b/traces/benchmark.go
@@ -122,7 +122,7 @@ func (benchmark *Benchmark) CommandArgs(commandName string) []string {
 }
 
 // If tracing is enabled, finds all *.trace files in `TracingDir` and
-// computes metrics, producing `TracingDir/merics.parquet.snappy`.
+// computes metrics, producing `TracingDir/metrics.parquet.snappy`.
 func ComputeMetrics() error {
 	if !IsTracingEnabled() {
 		return nil

--- a/traces/benchmark.go
+++ b/traces/benchmark.go
@@ -128,23 +128,27 @@ func ComputeMetrics() error {
 		return nil
 	}
 
+	wrap := func(err error) error {
+		return fmt.Errorf("ComputeMetrics() error: %w", err)
+	}
+
 	dir := TracingDir()
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return err
+		return wrap(err)
 	}
 
 	defer os.Chdir(cwd)
 
 	err = os.Chdir(dir)
 	if err != nil {
-		return err
+		return wrap(err)
 	}
 
 	files, err := ioutil.ReadDir(".")
 	if err != nil {
-		return err
+		return wrap(err)
 	}
 
 	var traceFiles []string
@@ -155,11 +159,11 @@ func ComputeMetrics() error {
 	}
 
 	if err := ToCsv(traceFiles, "traces.csv", "filename"); err != nil {
-		return err
+		return wrap(err)
 	}
 
 	if err := Metrics("traces.csv", "filename", NewParquetFileMetricsSink("metrics.parquet.snappy")); err != nil {
-		return err
+		return wrap(err)
 	}
 
 	return nil

--- a/traces/metrics.go
+++ b/traces/metrics.go
@@ -197,6 +197,7 @@ func Metrics(csvFile string, filenameColumn string, sink MetricsSink) error {
 func spanStart(row map[string]string) (time.Time, error) {
 	spanStart, err := parseTime(row["Span.Start"])
 	if err != nil {
+		err = fmt.Errorf("Failed to parse Span.Start time: %w", err)
 		return time.Time{}, err
 	}
 	return spanStart, nil
@@ -209,8 +210,8 @@ func spanDuration(row map[string]string) (time.Duration, error) {
 	}
 	spanEnd, err := parseTime(row["Span.End"])
 	if err != nil {
+		err = fmt.Errorf("Failed to parse Span.End time: %w", err)
 		return 0, err
-
 	}
 	dur := spanEnd.Sub(spanStart)
 	return dur, nil
@@ -250,7 +251,7 @@ func readLargeCsvFile(csvFile string, handleRow func(map[string]string) error) e
 		}
 
 		if err := handleRow(values); err != nil {
-			return err
+			return fmt.Errorf("Failed to parse %v: %w", values, err)
 		}
 	}
 

--- a/traces/metrics.go
+++ b/traces/metrics.go
@@ -184,7 +184,8 @@ func Metrics(csvFile string, filenameColumn string, sink MetricsSink) error {
 			return nil
 		}
 
-		if err := readLargeCsvFile(csvFile, emitMetricsFromRow); err != nil {
+		if err := readLargeCsvFile(csvFile,
+			tolerateFaults(csvFile, emitMetricsFromRow)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Tolerates CSV parse errors (writes to log instead of returning non-nil `err`) and annotates them better. The need for this came up when diagnosing failures in pulumi/templates repo.

Example better error display:

```
./pulumi-trace-tool metrics -csv ~/tmp/traces/traces.csv -filenamecolumn filename -parquet out.parquet 
2022/08/17 19:55:29 WARN ignoring failure to parse a row from /Users/anton/tmp/traces/traces.csv#precompute
  Error: Failed to parse Span.Start time: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
  Data:
                         Name: api/startUpdate
                          api: https://api.pulumi.com
                     filename: azure-classic-csharp-pulumi-destroy.trace
                       method: POST
                         path: /api/stacks/t0yv0/test-env2047447553/p-it-antons-mac-test-env20-d5e3a48d/update/b09f3df8-a56f-422e-867b-f416eca79f4e
                 responseCode: 200 OK
                        retry: false
```

